### PR TITLE
Migrate JSX rendering code into Jade templates

### DIFF
--- a/examples/todomvc/components/Footer.jade
+++ b/examples/todomvc/components/Footer.jade
@@ -1,0 +1,21 @@
+footer.footer
+  span.todo-count
+    strong=activeCount
+    if activeCount == 1
+      |  item left
+    else
+      |  items left
+      
+  
+  ul.filters
+    each filter in [SHOW_ALL, SHOW_ACTIVE, SHOW_COMPLETED]
+      li(key=filter)
+        a(
+          class=classnames({selected: filter === selectedFilter}),
+          style={cursor: 'pointer'},
+          onClick=onShow(filter)
+        )
+          =FILTER_TITLES[filter]
+        
+  if completedCount > 0
+    button.clear-completed(onClick=onClearCompleted) Clear completed

--- a/examples/todomvc/components/Footer.js
+++ b/examples/todomvc/components/Footer.js
@@ -1,64 +1,30 @@
-import React, { PropTypes, Component } from 'react'
-import classnames from 'classnames'
+import React, { PropTypes, Component }           from 'react'
+import classnames                                from 'classnames'
 import { SHOW_ALL, SHOW_COMPLETED, SHOW_ACTIVE } from '../constants/TodoFilters'
+import template                                  from './Footer.jade'
 
 const FILTER_TITLES = {
-  [SHOW_ALL]: 'All',
-  [SHOW_ACTIVE]: 'Active',
+  [SHOW_ALL]:       'All',
+  [SHOW_ACTIVE]:    'Active',
   [SHOW_COMPLETED]: 'Completed'
 }
 
 class Footer extends Component {
-  renderTodoCount() {
-    const { activeCount } = this.props
-    const itemWord = activeCount === 1 ? 'item' : 'items'
-
-    return (
-      <span className="todo-count">
-        <strong>{activeCount || 'No'}</strong> {itemWord} left
-      </span>
-    )
-  }
-
-  renderFilterLink(filter) {
-    const title = FILTER_TITLES[filter]
-    const { filter: selectedFilter, onShow } = this.props
-
-    return (
-      <a className={classnames({ selected: filter === selectedFilter })}
-         style={{ cursor: 'pointer' }}
-         onClick={() => onShow(filter)}>
-        {title}
-      </a>
-    )
-  }
-
-  renderClearButton() {
-    const { completedCount, onClearCompleted } = this.props
-    if (completedCount > 0) {
-      return (
-        <button className="clear-completed"
-                onClick={onClearCompleted} >
-          Clear completed
-        </button>
-      )
-    }
-  }
-
   render() {
-    return (
-      <footer className="footer">
-        {this.renderTodoCount()}
-        <ul className="filters">
-          {[ SHOW_ALL, SHOW_ACTIVE, SHOW_COMPLETED ].map(filter =>
-            <li key={filter}>
-              {this.renderFilterLink(filter)}
-            </li>
-          )}
-        </ul>
-        {this.renderClearButton()}
-      </footer>
-    )
+    const { activeCount, completedCount, onClearCompleted, onShow, filter: selectedFilter } = this.props
+
+    return template({
+      FILTER_TITLES:    FILTER_TITLES,
+      SHOW_ACTIVE:      SHOW_ACTIVE,
+      SHOW_ALL:         SHOW_ALL,
+      SHOW_COMPLETED:   SHOW_COMPLETED,
+      activeCount:      activeCount || 'No',
+      classnames:       classnames,
+      completedCount:   completedCount,
+      onClearCompleted: onClearCompleted,
+      onShow:           onShow,
+      selectedFilter:   selectedFilter
+    })
   }
 }
 

--- a/examples/todomvc/components/Header.jade
+++ b/examples/todomvc/components/Header.jade
@@ -1,0 +1,3 @@
+header.header
+  h1 todos
+  TodoTextInput(newTodo=true, onSave=handleSave, placeholder="What needs to be done?")

--- a/examples/todomvc/components/Header.js
+++ b/examples/todomvc/components/Header.js
@@ -1,5 +1,6 @@
 import React, { PropTypes, Component } from 'react'
-import TodoTextInput from './TodoTextInput'
+import TodoTextInput                   from './TodoTextInput'
+import template                        from './Header.jade'
 
 class Header extends Component {
   handleSave(text) {
@@ -9,14 +10,10 @@ class Header extends Component {
   }
 
   render() {
-    return (
-      <header className="header">
-          <h1>todos</h1>
-          <TodoTextInput newTodo
-                         onSave={this.handleSave.bind(this)}
-                         placeholder="What needs to be done?" />
-      </header>
-    )
+    return template({
+      TodoTextInput: TodoTextInput,
+      handleSave:    this.handleSave.bind(this)
+    });
   }
 }
 

--- a/examples/todomvc/components/MainSection.jade
+++ b/examples/todomvc/components/MainSection.jade
@@ -1,0 +1,26 @@
+section.main
+  if todos.length
+    input.toggle-all(
+      type="checkbox",
+      checked=completedCount == todos.length,
+      onChange=actions.completeAll
+    )
+  
+  ul.todo-list
+    each todo in filteredTodos
+      TodoItem(
+        key=todo.id,
+        todo=todo,
+        deleteTodo=actions.deleteTodo,
+        editTodo=actions.editTodo,
+        completeTodo=actions.completeTodo
+      )
+
+  if todos.length
+    Footer(
+      completedCount=completedCount,
+      activeCount=activeCount,
+      filter=filter,
+      onClearCompleted=handleClearCompleted,
+      onShow=handleShow
+    )

--- a/examples/todomvc/components/MainSection.js
+++ b/examples/todomvc/components/MainSection.js
@@ -1,11 +1,12 @@
-import React, { Component, PropTypes } from 'react'
-import TodoItem from './TodoItem'
-import Footer from './Footer'
+import React, { Component, PropTypes }           from 'react'
+import TodoItem                                  from './TodoItem'
+import Footer                                    from './Footer'
 import { SHOW_ALL, SHOW_COMPLETED, SHOW_ACTIVE } from '../constants/TodoFilters'
+import template                                  from './MainSection.jade'
 
 const TODO_FILTERS = {
-  [SHOW_ALL]: () => true,
-  [SHOW_ACTIVE]: todo => !todo.completed,
+  [SHOW_ALL]:       () => true,
+  [SHOW_ACTIVE]:    todo => !todo.completed,
   [SHOW_COMPLETED]: todo => todo.completed
 }
 
@@ -26,55 +27,25 @@ class MainSection extends Component {
     this.setState({ filter })
   }
 
-  renderToggleAll(completedCount) {
-    const { todos, actions } = this.props
-    if (todos.length > 0) {
-      return (
-        <input className="toggle-all"
-               type="checkbox"
-               checked={completedCount === todos.length}
-               onChange={actions.completeAll} />
-      )
-    }
-  }
-
-  renderFooter(completedCount) {
-    const { todos } = this.props
-    const { filter } = this.state
-    const activeCount = todos.length - completedCount
-
-    if (todos.length) {
-      return (
-        <Footer completedCount={completedCount}
-                activeCount={activeCount}
-                filter={filter}
-                onClearCompleted={this.handleClearCompleted.bind(this)}
-                onShow={this.handleShow.bind(this)} />
-      )
-    }
-  }
-
   render() {
     const { todos, actions } = this.props
-    const { filter } = this.state
+    const { filter }         = this.state
+    const filteredTodos      = todos.filter(TODO_FILTERS[filter])
+    const completedCount     = todos.reduce((count, todo) => todo.completed ? count + 1 : count, 0)
+    const activeCount        = todos.length - completedCount
 
-    const filteredTodos = todos.filter(TODO_FILTERS[filter])
-    const completedCount = todos.reduce((count, todo) =>
-      todo.completed ? count + 1 : count,
-      0
-    )
-
-    return (
-      <section className="main">
-        {this.renderToggleAll(completedCount)}
-        <ul className="todo-list">
-          {filteredTodos.map(todo =>
-            <TodoItem key={todo.id} todo={todo} {...actions} />
-          )}
-        </ul>
-        {this.renderFooter(completedCount)}
-      </section>
-    )
+    return template({
+      Footer:               Footer,
+      TodoItem:             TodoItem,
+      actions:              actions,
+      activeCount:          activeCount,
+      completedCount:       completedCount,
+      filter:               filter,
+      filteredTodos:        filteredTodos,
+      handleClearCompleted: this.handleClearCompleted.bind(this),
+      handleShow:           this.handleShow.bind(this),
+      todos:                todos
+    });
   }
 }
 

--- a/examples/todomvc/components/TodoItem.jade
+++ b/examples/todomvc/components/TodoItem.jade
@@ -1,0 +1,8 @@
+li(class=classnames({completed: todo.completed, editing: state.editing}))
+  if state.editing
+    TodoTextInput(text=todo.text, editing=state.editing, onSave=handleSave)
+  else
+    div.view
+      input.toggle(type="checkbox", checked=todo.completed, onChange=completeTodo)
+      label(onDoubleClick=handleDoubleClick)=todo.text
+      button.destroy(onClick=deleteTodo)

--- a/examples/todomvc/components/TodoItem.js
+++ b/examples/todomvc/components/TodoItem.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react'
-import classnames from 'classnames'
-import TodoTextInput from './TodoTextInput'
+import classnames                      from 'classnames'
+import TodoTextInput                   from './TodoTextInput'
+import template                        from './TodoItem.jade'
 
 class TodoItem extends Component {
   constructor(props, context) {
@@ -24,39 +25,18 @@ class TodoItem extends Component {
   }
 
   render() {
-    const { todo, completeTodo, deleteTodo } = this.props
+    const { todo, completeTodo, deleteTodo } = this.props;
 
-    let element
-    if (this.state.editing) {
-      element = (
-        <TodoTextInput text={todo.text}
-                       editing={this.state.editing}
-                       onSave={(text) => this.handleSave(todo.id, text)} />
-      )
-    } else {
-      element = (
-        <div className="view">
-          <input className="toggle"
-                 type="checkbox"
-                 checked={todo.completed}
-                 onChange={() => completeTodo(todo.id)} />
-          <label onDoubleClick={this.handleDoubleClick.bind(this)}>
-            {todo.text}
-          </label>
-          <button className="destroy"
-                  onClick={() => deleteTodo(todo.id)} />
-        </div>
-      )
-    }
-
-    return (
-      <li className={classnames({
-        completed: todo.completed,
-        editing: this.state.editing
-      })}>
-        {element}
-      </li>
-    )
+    return template({
+      TodoTextInput:     TodoTextInput,
+      classnames:        classnames,
+      completeTodo:      () => completeTodo(todo.id),
+      deleteTodo:        () => deleteTodo(todo.id),
+      handleSave:        (text) => this.handleSave.bind(this)(todo.id, text),
+      handleDoubleClick: this.handleDoubleClick.bind(this),
+      state:             this.state,
+      todo:              todo
+    })
   }
 }
 

--- a/examples/todomvc/components/TodoTextInput.jade
+++ b/examples/todomvc/components/TodoTextInput.jade
@@ -1,0 +1,10 @@
+input(
+  class=classnames({edit: props.editing, 'new-todo': props.newTodo}),
+  type="text",
+  placeholder=props.placeholder,
+  autoFocus="true",
+  value=state.text,
+  onBlur=handleBlur,
+  onChange=handleChange,
+  onKeyDown=handleSubmit
+)

--- a/examples/todomvc/components/TodoTextInput.js
+++ b/examples/todomvc/components/TodoTextInput.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react'
-import classnames from 'classnames'
+import classnames                      from 'classnames'
+import template                        from './TodoTextInput.jade'
 
 class TodoTextInput extends Component {
   constructor(props, context) {
@@ -30,20 +31,14 @@ class TodoTextInput extends Component {
   }
 
   render() {
-    return (
-      <input className={
-        classnames({
-          edit: this.props.editing,
-          'new-todo': this.props.newTodo
-        })}
-        type="text"
-        placeholder={this.props.placeholder}
-        autoFocus="true"
-        value={this.state.text}
-        onBlur={this.handleBlur.bind(this)}
-        onChange={this.handleChange.bind(this)}
-        onKeyDown={this.handleSubmit.bind(this)} />
-    )
+    return template({
+      classnames:   classnames,
+      handleBlur:   this.handleBlur.bind(this),
+      handleChange: this.handleChange.bind(this),
+      handleSubmit: this.handleSubmit.bind(this),
+      props:        this.props,
+      state:        this.state
+    });
   }
 }
 

--- a/examples/todomvc/containers/App.jade
+++ b/examples/todomvc/containers/App.jade
@@ -1,0 +1,3 @@
+div
+  Header(addTodo=actions.addTodo)
+  MainSection(todos=todos, actions=actions)

--- a/examples/todomvc/containers/App.js
+++ b/examples/todomvc/containers/App.js
@@ -1,19 +1,21 @@
 import React, { Component, PropTypes } from 'react'
-import { bindActionCreators } from 'redux'
-import { connect } from 'react-redux'
-import Header from '../components/Header'
-import MainSection from '../components/MainSection'
-import * as TodoActions from '../actions/todos'
+import { bindActionCreators }          from 'redux'
+import { connect }                     from 'react-redux'
+import Header                          from '../components/Header'
+import MainSection                     from '../components/MainSection'
+import * as TodoActions                from '../actions/todos'
+import template                        from './App.jade'
 
 class App extends Component {
   render() {
     const { todos, actions } = this.props
-    return (
-      <div>
-        <Header addTodo={actions.addTodo} />
-        <MainSection todos={todos} actions={actions} />
-      </div>
-    )
+
+    return template({
+      Header:      Header,
+      MainSection: MainSection,
+      actions:     actions,
+      todos:       todos
+    });
   }
 }
 

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -29,6 +29,7 @@
     "babel-plugin-react-transform": "^1.1.0",
     "expect": "^1.8.0",
     "express": "^4.13.3",
+    "jade-react-loader": "^1.0.0",
     "jsdom": "^5.6.1",
     "mocha": "^2.2.5",
     "node-libs-browser": "^0.5.2",

--- a/examples/todomvc/webpack.config.js
+++ b/examples/todomvc/webpack.config.js
@@ -27,6 +27,9 @@ module.exports = {
       test: /\.css?$/,
       loaders: [ 'style', 'raw' ],
       include: __dirname
+    }, {
+      test: /\.jade$/,
+      loader: 'jade-react-loader'
     }]
   }
 }


### PR DESCRIPTION
The purpose of this experiment is to move all JSX rendering logic to Jade templates.

To run this sample:

Clone this fork:

```
git clone https://github.com/AlejoFernandez/redux.git
```

Go to the `examples/todomvc/` folder and install node modules:

```
cd redux/examples/todomvc
npm install
```

Then run the server and point your browser to `https://localhost:3000`

```
node server.js
```
### Conclusions

LOC where reduced and rendering responsibility was moved away from Javascript code.
